### PR TITLE
Add GitHub Action to publish mom6-tools to PyPI on GitHub release.

### DIFF
--- a/.github/workflows/pypipublish.yaml
+++ b/.github/workflows/pypipublish.yaml
@@ -1,0 +1,26 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools setuptools-scm wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,20 @@
 MOM6-tools
 ============
-.. image:: https://travis-ci.com/gustavo-marques/mom6-tools.svg?style=for-the-badge
-    :target: https://travis-ci.org/gustavo-marques/mom6-tools
+.. image:: https://img.shields.io/travis/NCAR/mom6-tools/master?logo=travis&style=for-the-badge
+    :target: https://travis-ci.org/NCAR/mom6-tools
     :alt: Build Status
 
 .. image:: https://img.shields.io/readthedocs/mom6-tools/latest.svg?style=for-the-badge
     :target: https://mom6-tools.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
+
+.. image:: https://img.shields.io/pypi/v/mom6-tools.svg?style=for-the-badge
+    :target: https://pypi.org/project/mom6-tools
+    :alt: Python Package Index
+
+.. image:: https://img.shields.io/conda/vn/conda-forge/mom6-tools.svg?style=for-the-badge
+    :target: https://anaconda.org/conda-forge/mom6-tools
+    :alt: Conda Version
 
 Tools to support analysis of MOM6-CESM model solutions. See
 documentation_ for more information.
@@ -17,7 +25,7 @@ documentation_ for more information.
 Installation (Coming Soon!)
 ----------------------------
 
-POP-tools can be installed from PyPI with pip:
+mom6-tools can be installed from PyPI with pip:
 
 .. code-block:: bash
 


### PR DESCRIPTION
This workflow will be automatically triggered whenever a release is created on Github. For this workflow to automatically publish mom6-tools to PyPI (after a release is created), the repo admin will need to add `PYPI_USERNAME` and `PYPI_PASSWORD` secrets in https://github.com/NCAR/mom6-tools/settings/secrets.

To set the PYPI credentials:

- Head over to https://pypi.org/manage/account/ to create an API token
- the PYPI_USERNAME can be set to `__token__`
- the PYPI_PASSWORD secret is set to the API token
