### PR TITLE
Replace pkg_resources version lookup

### DIFF
--- a/mom6_tools/__init__.py
+++ b/mom6_tools/__init__.py
@@ -7,7 +7,7 @@ It relies on the following python packages:
  - etc
 '''
 
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import PackageNotFoundError, version
 
 #from MOM6grid import *
 #from section_transports import *
@@ -15,7 +15,7 @@ from pkg_resources import DistributionNotFound, get_distribution
 #from poleward_heat_transport import *
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = version('mom6-tools')
+except PackageNotFoundError:
     # package is not installed
     pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ test = pytest
 
 [isort]
 known_first_party=mom6_tools
-known_third_party=dask,jinja2,numba,numpy,pkg_resources,pytest,setuptools,xarray,yaml,netCDF4,matplotlib
+known_third_party=dask,jinja2,numba,numpy,pytest,setuptools,xarray,yaml,netCDF4,matplotlib
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0


### PR DESCRIPTION
## Summary

- replace the package version lookup with `importlib.metadata.version(mom6-tools)`
- keep the existing fallback behavior for source trees that are not installed as a package
- remove the now-unused `pkg_resources` entry from the isort third-party list

Fixes #75.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`
- `rg -n pkg_resources|get_distribution|DistributionNotFound .`
- Not run locally