### PR TITLE
Move from pkg_resources to importlib.metadata

### DIFF
--- a/mom6_tools/__init__.py
+++ b/mom6_tools/__init__.py
@@ -7,7 +7,7 @@ It relies on the following python packages:
  - etc
 '''
 
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import version, PackageNotFoundError
 
 #from MOM6grid import *
 #from section_transports import *
@@ -15,7 +15,8 @@ from pkg_resources import DistributionNotFound, get_distribution
 #from poleward_heat_transport import *
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = version(__name__)
+except PackageNotFoundError:
     # package is not installed
+    __version__ = None
     pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ test = pytest
 
 [isort]
 known_first_party=mom6_tools
-known_third_party=dask,jinja2,numba,numpy,pkg_resources,pytest,setuptools,xarray,yaml,netCDF4,matplotlib
+known_third_party=dask,jinja2,numba,numpy,pytest,setuptools,xarray,yaml,netCDF4,matplotlib
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0


### PR DESCRIPTION
`pkg_resources` was moved from `setuptools` in v82.0.0. The recommendation is to use `importlib.metadata` instead.

Fixes #75

Testing:

Using 49eeefc with python 3.13.12

```python
>>> import mom6_tools
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    import mom6_tools
  File "/glade/work/mlevy/codes/CUPiD/externals/mom6-tools/mom6_tools/__init__.py", line 10, in <module>
    from pkg_resources import DistributionNotFound, get_distribution
ModuleNotFoundError: No module named 'pkg_resources'
>>>
```

This branch

```python
>>> import mom6_tools
>>>
```