### PR TITLE
Add mom6-tools_{script} executable

### DIFF
--- a/mom6_tools/TS_levels.py
+++ b/mom6_tools/TS_levels.py
@@ -39,7 +39,7 @@ def parseCommandLine():
                               to compare against. Default is woa-2018-tx2_3v2-annual-all''')
   parser.add_argument('-debug',   help='''Add priting statements for debugging purposes''', action="store_true")
   optCmdLineArgs = parser.parse_args()
-  driver(optCmdLineArgs)
+  return optCmdLineArgs
 
 #-- This is where all the action happends, i.e., functions for each diagnostic are called.
 
@@ -427,6 +427,16 @@ def score_plot2(x,y,vals, cmin=None, cmap=plt.cm.bwr,title='',nbins=50, units=''
 
   plt.close()
   return
-# Invoke parseCommandLine(), the top-level prodedure
-if __name__ == '__main__': parseCommandLine()
+
+
+def main():
+  '''
+  Main procedure that calls the driver.
+  '''
+  args = parseCommandLine()
+  driver(args)
+
+# Invoke main() which calls parseCommandLine() and the driver.
+if __name__ == '__main__':
+  main()
 

--- a/mom6_tools/bouyancy_flux.py
+++ b/mom6_tools/bouyancy_flux.py
@@ -45,7 +45,7 @@ def parseCommandLine():
                       help='''The heat capacity of sea water. (default = 3992.0 J kg-1 K-1)''')
   parser.add_argument('-debug',   help='''Add priting statements for debugging purposes''', action="store_true")
   optCmdLineArgs = parser.parse_args()
-  driver(optCmdLineArgs)
+  return optCmdLineArgs
 
 #-- This is where all the action happends, i.e., functions for each diagnostic are called.
 
@@ -194,6 +194,15 @@ def driver(args):
 
   return
 
-# Invoke parseCommandLine(), the top-level prodedure
-if __name__ == '__main__': parseCommandLine()
+
+def main():
+  '''
+  Main procedure that calls the driver.
+  '''
+  args = parseCommandLine()
+  driver(args)
+
+# Invoke main() which calls parseCommandLine() and the driver.
+if __name__ == '__main__':
+  main()
 

--- a/mom6_tools/equatorial_comparison.py
+++ b/mom6_tools/equatorial_comparison.py
@@ -38,7 +38,7 @@ def parseCommandLine():
                               to compare against. Default is woa-2018-tx2_3v2-annual-all''')
   parser.add_argument('-debug',   help='''Add priting statements for debugging purposes''', action="store_true")
   optCmdLineArgs = parser.parse_args()
-  driver(optCmdLineArgs)
+  return optCmdLineArgs
 
 #-- This is where all the action happends, i.e., functions for each diagnostic are called.
 
@@ -289,6 +289,16 @@ def driver(args):
 
   return
 
-# Invoke parseCommandLine(), the top-level prodedure
-if __name__ == '__main__': parseCommandLine()
+
+
+def main():
+  '''
+  Main procedure that calls the driver.
+  '''
+  args = parseCommandLine()
+  driver(args)
+
+# Invoke main() which calls parseCommandLine() and the driver.
+if __name__ == '__main__':
+  main()
 

--- a/mom6_tools/forcing.py
+++ b/mom6_tools/forcing.py
@@ -35,7 +35,7 @@ def parseCommandLine():
                       help='''Number of workers to use (default=0, serial job).''')
   parser.add_argument('-debug',   help='''Add priting statements for debugging purposes''', action="store_true")
   optCmdLineArgs = parser.parse_args()
-  driver(optCmdLineArgs)
+  return optCmdLineArgs
 
 #-- This is where all the action happends, i.e., functions for each diagnostic are called.
 
@@ -100,6 +100,16 @@ def driver(args):
 
   return
 
-# Invoke parseCommandLine(), the top-level prodedure
-if __name__ == '__main__': parseCommandLine()
+
+
+def main():
+  '''
+  Main procedure that calls the driver.
+  '''
+  args = parseCommandLine()
+  driver(args)
+
+# Invoke main() which calls parseCommandLine() and the driver.
+if __name__ == '__main__':
+  main()
 

--- a/mom6_tools/latlon_analysis.py
+++ b/mom6_tools/latlon_analysis.py
@@ -63,7 +63,7 @@ def parseCommandLine():
       action="store_true")
 
   optCmdLineArgs = parser.parse_args()
-  driver(optCmdLineArgs)
+  return optCmdLineArgs
 
 #-- This is where all the action happends, i.e., functions for each diagnostic are called.
 
@@ -218,6 +218,16 @@ def create_xarray_dataset(variable,unit,time):
    return ds
 
 
-# Invoke parseCommandLine(), the top-level prodedure
-if __name__ == '__main__': parseCommandLine()
+
+
+def main():
+  '''
+  Main procedure that calls the driver.
+  '''
+  args = parseCommandLine()
+  driver(args)
+
+# Invoke main() which calls parseCommandLine() and the driver.
+if __name__ == '__main__':
+  main()
 

--- a/mom6_tools/mom6_xyplot.py
+++ b/mom6_tools/mom6_xyplot.py
@@ -52,7 +52,7 @@ def parseCommandLine():
   optCmdLineArgs = parser.parse_args()
   global case_name
   case_name = optCmdLineArgs.case_name
-  driver(optCmdLineArgs)
+  return optCmdLineArgs
 
 #-- This is where all the action happends, i.e., functions for each diagnostic are called.
 
@@ -106,8 +106,18 @@ def latlon_plot(args, ncfile, grd, variable):
 
   return
 
-# Invoke parseCommandLine(), the top-level prodedure
-if __name__ == '__main__': parseCommandLine()
+
+
+def main():
+  '''
+  Main procedure that calls the driver.
+  '''
+  args = parseCommandLine()
+  driver(args)
+
+# Invoke main() which calls parseCommandLine() and the driver.
+if __name__ == '__main__':
+  main()
 
 
 

--- a/mom6_tools/surface.py
+++ b/mom6_tools/surface.py
@@ -38,7 +38,7 @@ def parseCommandLine():
                       help='''Number of workers to use (default=0, serial job).''')
   parser.add_argument('-debug',   help='''Add priting statements for debugging purposes''', action="store_true")
   optCmdLineArgs = parser.parse_args()
-  driver(optCmdLineArgs)
+  return optCmdLineArgs
 
 #-- This is where all the action happends, i.e., functions for each diagnostic are called.
 
@@ -547,6 +547,15 @@ def get_BLD(ds, var, grd, args):
          title=str(args.casename) + ' ' +str(args.start_date) + ' to '+ str(args.end_date) + \
               ' JFM (SH), JAS (NH)')
   return
-# Invoke parseCommandLine(), the top-level prodedure
-if __name__ == '__main__': parseCommandLine()
+
+def main():
+  '''
+  Main procedure that calls the driver.
+  '''
+  args = parseCommandLine()
+  driver(args)
+
+# Invoke main() which calls parseCommandLine() and the driver.
+if __name__ == '__main__':
+  main()
 

--- a/mom6_tools/tao_mooring_comparison.py
+++ b/mom6_tools/tao_mooring_comparison.py
@@ -35,7 +35,7 @@ def parseCommandLine():
                         help='''Number of workers to use (default=0, serial job).''')
     parser.add_argument('-debug',   help='''Add priting statements for debugging purposes''', action="store_true")
     optCmdLineArgs = parser.parse_args()
-    driver(optCmdLineArgs)
+    return optCmdLineArgs
 
     #-- This is where all the action happends, i.e., functions for each diagnostic are called.
 
@@ -204,5 +204,15 @@ def driver(args):
 
     return
 
-# Invoke parseCommandLine(), the top-level prodedure
-if __name__ == '__main__': parseCommandLine()
+
+
+def main():
+  '''
+  Main procedure that calls the driver.
+  '''
+  args = parseCommandLine()
+  driver(args)
+
+# Invoke main() which calls parseCommandLine() and the driver.
+if __name__ == '__main__':
+  main()

--- a/mom6_tools/wind_stress.py
+++ b/mom6_tools/wind_stress.py
@@ -38,7 +38,7 @@ def parseCommandLine():
                       help='''Number of workers to use (default=0, serial job).''')
   parser.add_argument('-debug',   help='''Add priting statements for debugging purposes''', action="store_true")
   optCmdLineArgs = parser.parse_args()
-  driver(optCmdLineArgs)
+  return optCmdLineArgs
 
 #-- This is where all the action happends, i.e., functions for each diagnostic are called.
 
@@ -153,6 +153,16 @@ def driver(args):
 
   return
 
-# Invoke parseCommandLine(), the top-level prodedure
-if __name__ == '__main__': parseCommandLine()
+
+
+def main():
+  '''
+  Main procedure that calls the driver.
+  '''
+  args = parseCommandLine()
+  driver(args)
+
+# Invoke main() which calls parseCommandLine() and the driver.
+if __name__ == '__main__':
+  main()
 

--- a/setup.py
+++ b/setup.py
@@ -50,4 +50,31 @@ setup(
     use_scm_version={'version_scheme': 'post-release', 'local_scheme': 'dirty-tag'},
     setup_requires=['setuptools_scm', 'setuptools>=30.3.0'],
     zip_safe=False,
+    entry_points={
+        'console_scripts': [
+            'mom6-tools_aaiw_pv=mom6_tools.aaiw_pv:main',
+            'mom6-tools_buoyancy_flux=mom6_tools.buoyancy_flux:main',
+            'mom6-tools_compute_basin_reductions=mom6_tools.compute_basin_reductions:main',
+            'mom6-tools_create_cesm_diagnostics=mom6_tools.create_cesm_diagnostics:main',
+            'mom6-tools_create_climatology=mom6_tools.create_climatology:main',
+            'mom6-tools_create_mom6_tools=mom6_tools.create_mom6_tools:main',
+            'mom6-tools_diff_rms=mom6_tools.diff_rms:main',
+            'mom6-tools_drift=mom6_tools.drift:main',
+            'mom6-tools_enso=mom6_tools.enso:main',
+            'mom6-tools_equatorial_comparison=mom6_tools.equatorial_comparison:main',
+            'mom6-tools_forcing=mom6_tools.forcing:main',
+            'mom6-tools_latlon_analysis=mom6_tools.latlon_analysis:main',
+            'mom6-tools_moc=mom6_tools.moc:main',
+            'mom6-tools_moc_sigma2=mom6_tools.moc_sigma2:main',
+            'mom6-tools_mom6_xyplot=mom6_tools.mom6_xyplot:main',
+            'mom6-tools_poleward_heat_transport=mom6_tools.poleward_heat_transport:main',
+            'mom6-tools_section_transports=mom6_tools.section_transports:main',
+            'mom6-tools_stats=mom6_tools.stats:main',
+            'mom6-tools_surface=mom6_tools.surface:main',
+            'mom6-tools_tao_mooring_comparison=mom6_tools.tao_mooring_comparison:main',
+            'mom6-tools_TS_levels=mom6_tools.TS_levels:main',
+            'mom6-tools_verticalvelocity=mom6_tools.verticalvelocity:main',
+            'mom6-tools_wind_stress=mom6_tools.wind_stress:main',
+        ]
+    }
 )


### PR DESCRIPTION
This command runs `mom6-tools/{script}.py`; all 23 executable python scripts can now be accessed this way.

Fixes #79