### PR TITLE
Change geom_file to be a required input of MOM6grid

### DIFF
--- a/mom6_tools/DiagsCase.py
+++ b/mom6_tools/DiagsCase.py
@@ -289,22 +289,24 @@ class DiagsCase(object,):
 
         return all_matched_files
 
+    # William Xu: I'm not seeing this being used anywhere, so I'm commenting it out instead of fixing it for now.
+    # The file names for *static.nc and *ocean_geometry.nc should be read from diag_config.yml, instead of hard-coded.
+    # def _generate_grid(self):
+    #     dout_s = dcase.get_value('DOUT_S')
+    #     if dout_s:
+    #       outdir = dcase.get_value('DOUT_S_ROOT')+'/ocn/hist/'
+    #     else:
+    #       outdir = dcase.get_value('RUNDIR')
+    #     static_file_path = os.path.join(outdir, f"{self.casename}.mom6.static.nc")
+    #     geom_file_path = os.path.join(outdir, f"{self.casename}.mom6.ocean_geometry.nc")
+    #     self._grid = MOM6grid(static_file_path, geom_file_path, self.xrformat)
 
-    def _generate_grid(self):
-        dout_s = dcase.get_value('DOUT_S')
-        if dout_s:
-          outdir = dcase.get_value('DOUT_S_ROOT')+'/ocn/hist/'
-        else:
-          outdir = dcase.get_value('RUNDIR')
-        static_file_path = os.path.join(outdir, f"{self.casename}.mom6.static.nc")
-        self._grid = MOM6grid(static_file_path, self.xrformat)
-
-    @property
-    def grid(self):
-        """ MOM6grid instance """
-        if not self._grid:
-            self._generate_grid()
-        return self._grid
+    # @property
+    # def grid(self):
+    #     """ MOM6grid instance """
+    #     if not self._grid:
+    #         self._generate_grid()
+    #     return self._grid
 
 
     def stage_dset(self, fields:list):

--- a/mom6_tools/MOM6grid.py
+++ b/mom6_tools/MOM6grid.py
@@ -1,7 +1,7 @@
 import xarray as xr
 
 # -- return MOM6 grid object
-def MOM6grid(grd_file, geom_file=None, xrformat=False):
+def MOM6grid(grd_file, geom_file, xrformat=False):
     """
     Return an object or xarray Dataset with the MOM6 grid data.
 
@@ -10,8 +10,8 @@ def MOM6grid(grd_file, geom_file=None, xrformat=False):
     grd_file : str
     Path to the static file.
 
-    geom_file : str, optional
-    If provided, override the coordinates in grd_file using those from this file. This is necessary when
+    geom_file : str
+    Override the coordinates in grd_file using those from this file. This is necessary when
     land-block elimination is enabled, which leads to NaNs in grd_file.
 
     xrformat : boolean, optional
@@ -26,13 +26,12 @@ def MOM6grid(grd_file, geom_file=None, xrformat=False):
     try: nc = xr.open_dataset(grd_file, decode_times=False)
     except: raise Exception('Could not find file', grd_file)
 
-    if geom_file:
-      try: geom = xr.open_dataset(geom_file, decode_times=False)
-      except: raise Exception('Could not find file', geom_file)
-      nc['geolat'].values = geom.geolat.values
-      nc['geolon'].values = geom.geolon.values
-      nc['geolat_c'].values = geom.geolatb.values
-      nc['geolon_c'].values = geom.geolonb.values
+    try: geom = xr.open_dataset(geom_file, decode_times=False)
+    except: raise Exception('Could not find file', geom_file)
+    nc['geolat'].values = geom.geolat.values
+    nc['geolon'].values = geom.geolon.values
+    nc['geolat_c'].values = geom.geolatb.values
+    nc['geolon_c'].values = geom.geolonb.values
 
     # fixes non-monotonic longitudes
     mgeolon = xr.where(nc.geolon < nc.geolon[-1,0],nc.geolon+360,nc.geolon).rename({'mgeolon'})

--- a/mom6_tools/TS_levels.py
+++ b/mom6_tools/TS_levels.py
@@ -79,13 +79,8 @@ def driver(args):
   if not args.end_date : args.end_date = avg['end_date']
 
   # read grid info
-  geom_file = OUTDIR+'/'+args.geom
-  if os.path.exists(geom_file):
-    grd = MOM6grid(OUTDIR+'/'+args.static, geom_file)
-    grd_xr = MOM6grid(OUTDIR+'/'+args.static, geom_file, xrformat=True);
-  else:
-    grd = MOM6grid(OUTDIR+'/'+args.static)
-    grd_xr = MOM6grid(OUTDIR+'/'+args.static, xrformat=True);
+  grd = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom)
+  grd_xr = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom, xrformat=True);
 
   # create masks
   try:

--- a/mom6_tools/aaiw_pv.py
+++ b/mom6_tools/aaiw_pv.py
@@ -80,11 +80,7 @@ def main(stream=False):
   args.outdir = 'PNG/AAIW_PV/'
 
   # read grid info
-  geom_file = OUTDIR+'/'+args.geom
-  if os.path.exists(geom_file):
-    grd = MOM6grid(OUTDIR+'/'+args.static, geom_file, xrformat=True)
-  else:
-    grd = MOM6grid(OUTDIR+'/'+args.static, xrformat=True)
+  grd = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom, xrformat=True)
 
   try:
     depth = grd.depth_ocean

--- a/mom6_tools/bouyancy_flux.py
+++ b/mom6_tools/bouyancy_flux.py
@@ -66,6 +66,8 @@ def driver(args):
   dcase = DiagsCase(diag_config_yml['Case'])
   RUNDIR = dcase.get_value('RUNDIR')
   args.casename = dcase.casename
+  args.static = args.casename+diag_config_yml['Fnames']['static']
+  args.geom = args.casename+diag_config_yml['Fnames']['geom']
   print('Run directory is:', RUNDIR)
   print('Casename is:', args.casename)
   print('Number of workers: ', nw)
@@ -76,7 +78,7 @@ def driver(args):
   if not args.end_date : args.end_date = avg['end_date']
 
   # read grid info
-  grd = MOM6grid(RUNDIR+'/'+args.casename+'.mom6.static.nc')
+  grd = MOM6grid(RUNDIR+'/'+args.static, RUNDIR+'/'+args.geom)
 
   parallel = False
   if nw > 1:

--- a/mom6_tools/compute_basin_reductions.py
+++ b/mom6_tools/compute_basin_reductions.py
@@ -184,11 +184,7 @@ def main():
     args.static = args.casename+config['Fnames']['static']
 
     # read grid info
-    geom_file = OUTDIR+'/'+args.geom
-    if os.path.exists(geom_file):
-      grd = MOM6grid(OUTDIR+'/'+args.static, geom_file, xrformat=True)
-    else:
-      grd = MOM6grid(OUTDIR+'/'+args.static, xrformat=True)
+    grd = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom, xrformat=True)
 
     try:
       area = xr.where(grd.wet == 1, grd.area_t, 0.)

--- a/mom6_tools/create_climatology.py
+++ b/mom6_tools/create_climatology.py
@@ -222,11 +222,7 @@ def main():
                        )
 
       # read grid info
-      geom_file = OUTDIR+'/'+args.geom
-      if os.path.exists(geom_file):
-        grd_xr = MOM6grid(OUTDIR+'/'+args.static, geom_file, xrformat=True);
-      else:
-        grd_xr = MOM6grid(OUTDIR+'/'+args.static, xrformat=True);
+      grd = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom, xrformat=True)
 
       # Process variable in dataset
       process_dataset(ds, grd_xr, start_date, end_date, ocn_diag_root, args.casename, fname)

--- a/mom6_tools/diff_rms.py
+++ b/mom6_tools/diff_rms.py
@@ -553,6 +553,9 @@ def main(stream=False):
 
   # Create the case instance
   dcase = DiagsCase(diag_config_yml['Case'], xrformat=True)
+  args.casename = dcase.casename
+  args.static = args.casename+diag_config_yml['Fnames']['static']
+  args.geom = args.casename+diag_config_yml['Fnames']['geom']
   DOUT_S = dcase.get_value('DOUT_S')
   if DOUT_S:
     OUTDIR = dcase.get_value('DOUT_S_ROOT')+'/ocn/hist/'
@@ -571,8 +574,8 @@ def main(stream=False):
     os.system('mkdir ncfiles')
 
   # read grid
-  grd = MOM6grid(OUTDIR+'/'+dcase.casename+'.mom6.static.nc', xrformat=True)
-  #grd = MOM6grid('ocean.mom6.static.nc', xrformat=True)
+  grd = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom, xrformat=True)
+
   try:
     area = grd.area_t.where(grd.wet > 0)
   except:

--- a/mom6_tools/drift.py
+++ b/mom6_tools/drift.py
@@ -577,11 +577,7 @@ def main(stream=False):
     os.system('mkdir ncfiles')
 
   # read grid info
-  geom_file = OUTDIR+'/'+args.geom
-  if os.path.exists(geom_file):
-    grd = MOM6grid(OUTDIR+'/'+args.static, geom_file, xrformat=True)
-  else:
-    grd = MOM6grid(OUTDIR+'/'+args.static, xrformat=True)
+  grd = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom, xrformat=True)
 
   try:
     area = np.ma.masked_where(grd.wet == 0,grd.area_t)

--- a/mom6_tools/enso.py
+++ b/mom6_tools/enso.py
@@ -84,11 +84,7 @@ def main(stream=False):
   args.outdir = 'PNG/ENSO/'
 
   # read grid info
-  geom_file = OUTDIR+'/'+args.geom
-  if os.path.exists(geom_file):
-    grd = MOM6grid(OUTDIR+'/'+args.static, geom_file, xrformat=True)
-  else:
-    grd = MOM6grid(OUTDIR+'/'+args.static, xrformat=True)
+  grd = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom, xrformat=True)
 
   try:
     depth = grd.depth_ocean

--- a/mom6_tools/equatorial_comparison.py
+++ b/mom6_tools/equatorial_comparison.py
@@ -80,11 +80,7 @@ def driver(args):
   if not args.end_date : args.end_date = avg['end_date']
 
   # read grid info
-  geom_file = OUTDIR+'/'+args.geom
-  if os.path.exists(geom_file):
-    grd = MOM6grid(OUTDIR+'/'+args.static, geom_file, xrformat=True)
-  else:
-    grd = MOM6grid(OUTDIR+'/'+args.static, xrformat=True)
+  grd = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom, xrformat=True)
 
   # select Equatorial region
   grd_eq = grd.sel(yh=slice(-10,10))

--- a/mom6_tools/forcing.py
+++ b/mom6_tools/forcing.py
@@ -57,6 +57,8 @@ def driver(args):
     OUTDIR = dcase.get_value('RUNDIR')
 
   args.casename = dcase.casename
+  args.static = args.casename+diag_config_yml['Fnames']['static']
+  args.geom = args.casename+diag_config_yml['Fnames']['geom']
   print('Output directory is:', OUTDIR)
   print('Casename is:', args.casename)
   print('Number of workers: ', nw)
@@ -67,7 +69,7 @@ def driver(args):
   if not args.end_date : args.end_date = avg['end_date']
 
   # read grid info
-  grd = MOM6grid(OUTDIR+'/'+args.casename+'.mom6.static.nc')
+  grd = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom)
 
   parallel = False
   if nw > 1:

--- a/mom6_tools/latlon_analysis.py
+++ b/mom6_tools/latlon_analysis.py
@@ -89,13 +89,8 @@ def driver(args):
   args.static = casename+diag_config_yml['Fnames']['static']
   args.geom =   casename+diag_config_yml['Fnames']['geom']
 
-  # mom6 grid
   # read grid info
-  geom_file = OUTDIR+'/'+args.geom
-  if os.path.exists(geom_file):
-    grd = MOM6grid(OUTDIR+'/'+args.static, geom_file)
-  else:
-    grd = MOM6grid(OUTDIR+'/'+args.static)
+  grd = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom)
 
   variables = args.variables.split(',')
   time_mean_latlon(args,grd,variables)

--- a/mom6_tools/moc.py
+++ b/mom6_tools/moc.py
@@ -66,11 +66,7 @@ def main():
   args.geom = args.casename+diag_config_yml['Fnames']['geom']
 
   # read grid info
-  geom_file = OUTDIR+'/'+args.geom
-  if os.path.exists(geom_file):
-    grd = MOM6grid(OUTDIR+'/'+args.static, geom_file)
-  else:
-    grd = MOM6grid(OUTDIR+'/'+args.static)
+  grd = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom)
 
   try:
     depth = grd.depth_ocean

--- a/mom6_tools/moc_sigma2.py
+++ b/mom6_tools/moc_sigma2.py
@@ -74,13 +74,8 @@ def main():
   args.label = diag_config_yml['Case']['SNAME']
 
   # read grid info
-  geom_file = OUTDIR+'/'+args.geom
-  if os.path.exists(geom_file):
-    grd = MOM6grid(OUTDIR+'/'+args.static, geom_file)
-    grd_xr = MOM6grid(OUTDIR+'/'+args.static, geom_file, xrformat=True)
-  else:
-    grd = MOM6grid(OUTDIR+'/'+args.static)
-    grd_xr = MOM6grid(OUTDIR+'/'+args.static, xrformat=True)
+  grd = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom)
+  grd_xr = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom, xrformat=True)
 
   try:
     depth = grd.depth_ocean

--- a/mom6_tools/poleward_heat_transport.py
+++ b/mom6_tools/poleward_heat_transport.py
@@ -71,11 +71,8 @@ def main(stream=False):
   args.savefigs = False
 
   # read grid info
-  geom_file = OUTDIR+'/'+args.geom
-  if os.path.exists(geom_file):
-    grd = MOM6grid(OUTDIR+'/'+args.static, geom_file)
-  else:
-    grd = MOM6grid(OUTDIR+'/'+args.static)
+  grd = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom)
+  
   try:
     depth = grd.depth_ocean
   except:

--- a/mom6_tools/stats.py
+++ b/mom6_tools/stats.py
@@ -415,11 +415,8 @@ def main(stream=False):
     os.system('mkdir ncfiles')
 
   # read grid info
-  geom_file = OUTDIR+'/'+args.geom
-  if os.path.exists(geom_file):
-    grd = MOM6grid(OUTDIR+'/'+args.static, geom_file, xrformat=True)
-  else:
-    grd = MOM6grid(OUTDIR+'/'+args.static, xrformat=True)
+  grd = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom, xrformat=True)
+  
   try:
     area = grd.area_t.where(grd.wet > 0)
   except:

--- a/mom6_tools/surface.py
+++ b/mom6_tools/surface.py
@@ -76,11 +76,7 @@ def driver(args):
   args.savefigs = True
 
   # read grid info
-  geom_file = OUTDIR+'/'+args.geom
-  if os.path.exists(geom_file):
-    grd = MOM6grid(OUTDIR+'/'+args.static, geom_file)
-  else:
-    grd = MOM6grid(OUTDIR+'/'+args.static)
+  grd = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom)
 
   parallel = False
   if nw > 1:

--- a/mom6_tools/tao_mooring_comparison.py
+++ b/mom6_tools/tao_mooring_comparison.py
@@ -77,11 +77,7 @@ def driver(args):
 
 
     # read grid info
-    geom_file = OUTDIR+'/'+args.geom
-    if os.path.exists(geom_file):
-      grd = MOM6grid(OUTDIR+'/'+args.static, geom_file, xrformat=True)
-    else:
-      grd = MOM6grid(OUTDIR+'/'+args.static, xrformat=True)
+    grd = MOM6grid(OUTDIR+'/'+args.static, OUTDIR+'/'+args.geom, xrformat=True)
 
     # Get index for equator on model grid
     jeq = np.abs(grd['geolat'][:,0]).argmin().values

--- a/mom6_tools/wind_stress.py
+++ b/mom6_tools/wind_stress.py
@@ -56,6 +56,8 @@ def driver(args):
   dcase = DiagsCase(diag_config_yml['Case'])
   RUNDIR = dcase.get_value('RUNDIR')
   args.casename = dcase.casename
+  args.static = args.casename+diag_config_yml['Fnames']['static']
+  args.geom = args.casename+diag_config_yml['Fnames']['geom']
   print('Run directory is:', RUNDIR)
   print('Casename is:', args.casename)
   print('Number of workers: ', nw)
@@ -66,7 +68,7 @@ def driver(args):
   if not args.end_date : args.end_date = avg['end_date']
 
   # read grid info
-  grd = MOM6grid(RUNDIR+'/'+args.casename+'.mom6.static.nc')
+  grd = MOM6grid(RUNDIR+'/'+args.static, RUNDIR+'/'+args.geom)
 
   parallel = False
   if nw > 1:


### PR DESCRIPTION
The coordinates in *ocean_geometry.nc are used to override those from *static.nc, which is necessary when land-block elimination is enabled and leads to NaNs in *static.nc.

This PR should fix issue #80 