### PR TITLE
Add DWBC diagnostic, expand heat transport time series, and rewrite wind stress module

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,7 @@ dependencies:
   - matplotlib
   - cftime
   - scipy
+  - gsw
   - jupyter
   - cmocean
   - cartopy

--- a/mom6_tools/compute_basin_reductions.py
+++ b/mom6_tools/compute_basin_reductions.py
@@ -28,7 +28,7 @@ def parse_args():
         "over specified basin masks to extract and average/integrate the variable within each region.")
     parser.add_argument('config_yml', type=str, help='Path to YAML configuration file.')
     parser.add_argument('-v', '--variable', type=str, default='', help='Variable to be processed (default is empty, it will process all 2D variables on tracer points).')
-    parser.add_argument('-s', '--stream', type=str, default='.mom6.h.native.????-??.nc', help='History file stream (default is .mom6.h.native.????-??.nc)')
+    parser.add_argument('-s', '--stream', type=str, default='.mom6.h.native.*.nc', help='History file stream (default is .mom6.h.native.*.nc)')
     parser.add_argument('-f', '--fname', type=str, default='native', help='Name of the history file stream (default is native)')
     parser.add_argument('-sd', '--start_date', type=str, default='', help='Start date for averaging (YYYY-MM).')
     parser.add_argument('-ed', '--end_date', type=str, default='', help='End date for averaging (YYYY-MM).')

--- a/mom6_tools/dwbc.py
+++ b/mom6_tools/dwbc.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python
+
+import xarray as xr
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+from scipy.interpolate import interp1d
+import warnings, os, yaml, argparse, dask
+from datetime import datetime
+import gsw
+from ncar_jobqueue import NCARCluster
+from dask.distributed import Client
+from mom6_tools.m6toolbox import cime_xmlquery
+
+warnings.filterwarnings('ignore')
+
+# Observational / topography data path
+DWBC_DATA = '/glade/campaign/cgd/oce/datasets/obs/DWBC_26.5N/'
+
+# Transect definition (following Bilo & Johns 2020)
+LAT_TRANSECT = 26.5
+LON_MIN = -77.0
+LON_MAX = -70.0
+
+
+def options():
+  try: import argparse
+  except: raise Exception('This version of python is not new enough. python 2.7 or newer is required.')
+  parser = argparse.ArgumentParser(description='''Script for plotting the 26.5N DWBC transect
+    (mean meridional velocity, 77W-70W) following Bilo & Johns (2020).''')
+  parser.add_argument('diag_config_yml_path', type=str, help='''Full path to the yaml file  \
+    describing the run and diagnostics to be performed.''')
+  parser.add_argument('-sd','--start_date', type=str, default='',
+                      help='''Start year to compute averages. Default is to use value set in diag_config_yml_path''')
+  parser.add_argument('-ed','--end_date', type=str, default='',
+                      help='''End year to compute averages. Default is to use value set in diag_config_yml_path''')
+  parser.add_argument('-nw','--number_of_workers',  type=int, default=0,
+                      help='''Number of workers to use (default=0, serial).''')
+  parser.add_argument('-debug',   help='''Add priting statements for debugging purposes''',
+                      action="store_true")
+  cmdLineArgs = parser.parse_args()
+  return cmdLineArgs
+
+
+def base_26N_transect(lon_min=-77.0, lon_max=-70.0):
+  """Return (fig, ax_lon, ax_dist) with observed topography and station markers."""
+  topography = xr.open_dataset(DWBC_DATA + '/topography_26.5N.nc')
+  ftopo = interp1d(topography.longitude.values,
+                   topography.topography.values, kind='linear')
+
+  stations = xr.open_dataset(DWBC_DATA + '/stations_positions.nc')
+  moorings = xr.open_dataset(DWBC_DATA + '/mooring_instrumentation.nc')
+  mtopo    = ftopo(moorings.longitude.values)
+
+  fig    = plt.figure(figsize=(10, 7), facecolor='w')
+  ax_lon = plt.gca()
+  ax_dist = ax_lon.twiny()
+
+  # Stations
+  ax_lon.plot(stations.longitude.values,
+              np.zeros(stations.longitude.shape[0]),
+              'o', mfc='darkorange', markeredgecolor='k', markersize=7, zorder=9)
+
+  # Topography fill
+  ax_lon.fill_between(topography.longitude.values, topography.topography,
+                      y2=7000, color='k', zorder=10)
+
+  # Mooring positions
+  ax_lon.plot(moorings.longitude, mtopo + 120.0,
+              '^', mfc='darkorange', markeredgecolor='k', ms=12, zorder=11)
+
+  # Axes layout
+  ax_lon.xaxis.tick_bottom()
+  ax_dist.xaxis.tick_top()
+  ax_dist.set_xlabel('Distance (km)', fontsize=18)
+  ax_lon.set_ylabel('Depth (m)', fontsize=22)
+
+  lon_range     = np.arange(-77.0, -69.0, 1.0)
+  lon_range_str = [r'%i$^{\circ}$W' % int(np.abs(l)) for l in lon_range]
+
+  ax_lon.set_yticks(range(0, 5500, 500))
+  ax_lon.set_xticks(lon_range)
+  ax_lon.set_xticklabels(lon_range_str, color='k', fontsize=18)
+  ax_dist.set_xticks(range(0, 700, 50))
+  ax_dist.tick_params(labelsize=15)
+  ax_lon.tick_params(labelsize=18)
+
+  ax_lon.set_ylim(5250, -20)
+  ax_lon.set_xlim(lon_min, lon_max)
+  ax_dist.set_xlim(0.0, stations.distance.max())
+
+  return fig, ax_lon, ax_dist
+
+
+def main():
+  # Get options
+  args = options()
+  nw = args.number_of_workers
+
+  os.makedirs('PNG/DWBC', exist_ok=True)
+  os.makedirs('ncfiles', exist_ok=True)
+
+  # Read in the yaml file
+  diag_config_yml = yaml.load(open(args.diag_config_yml_path,'r'), Loader=yaml.Loader)
+
+  caseroot = diag_config_yml['Case']['CASEROOT']
+  casename = cime_xmlquery(caseroot, 'CASE')
+  label = diag_config_yml['Case']['SNAME']
+  DOUT_S = cime_xmlquery(caseroot, 'DOUT_S')
+  if DOUT_S:
+    OUTDIR = cime_xmlquery(caseroot, 'DOUT_S_ROOT')+'/ocn/hist/'
+  else:
+    OUTDIR = cime_xmlquery(caseroot, 'RUNDIR')
+
+  z_stream    = casename + diag_config_yml['Fnames']['z']
+  static_file = OUTDIR + '/' + casename + diag_config_yml['Fnames']['static']
+
+  # set avg dates
+  avg = diag_config_yml['Avg']
+  if not args.start_date : args.start_date = avg['start_date']
+  if not args.end_date : args.end_date = avg['end_date']
+
+  print('Casename   :', casename)
+  print('OUTDIR     :', OUTDIR)
+  print('Date range :', args.start_date, '->', args.end_date)
+  print('Stream     :', z_stream)
+  print('Number of workers:', nw)
+
+  parallel = False
+  if nw > 1:
+    parallel = True
+    cluster = NCARCluster()
+    cluster.scale(nw)
+    client = Client(cluster)
+
+  # --- Compute time-mean meridional velocity at 26.5N ---
+  lat_transect = LAT_TRANSECT
+  lon_min = LON_MIN
+  lon_max = LON_MAX
+
+  def preprocess(ds):
+    """Keep only vo and select the transect latitude and longitude range."""
+    yq_sel = ds.yq.sel(yq=lat_transect, method='nearest').values
+    return ds[['vo']].sel(yq=yq_sel, method='nearest').sel(xh=slice(lon_min, lon_max))
+
+  print('Opening z-level files...')
+  startTime = datetime.now()
+  ds = xr.open_mfdataset(
+      OUTDIR + '/' + z_stream,
+      parallel=parallel,
+      data_vars='minimal',
+      coords='minimal',
+      compat='override',
+      preprocess=preprocess,
+  )
+  print('Time elapsed:', datetime.now() - startTime)
+
+  # Select date range and compute time mean
+  ds_sel = ds.sel(time=slice(args.start_date, args.end_date))
+  print('Time steps selected:', ds_sel.time.size)
+
+  print('Computing time mean...')
+  startTime = datetime.now()
+  vo_mean = ds_sel.vo.mean('time').compute()
+  print('Time elapsed:', datetime.now() - startTime)
+
+  print('vo_mean shape (z_l, xh):', vo_mean.shape)
+  print('Latitude selected (yq)  :', float(ds.yq))
+  print('Longitude range (xh)    :', vo_mean.xh.values[0], '->', vo_mean.xh.values[-1])
+
+  # --- Load model bathymetry along the transect ---
+  static = xr.open_dataset(static_file)
+  deptho = static['deptho'].sel(yh=lat_transect, method='nearest').sel(xh=slice(lon_min, lon_max))
+
+  # --- Save to netCDF ---
+  ds_out = vo_mean.to_dataset(name='vo')
+  ds_out['deptho'] = deptho
+  ds_out['vo'].attrs = {
+      'long_name'   : 'Time-mean meridional velocity at {:.1f}N'.format(lat_transect),
+      'units'       : 'm s-1',
+      'cell_methods': 'time: mean',
+  }
+  ds_out['deptho'].attrs = {
+      'long_name': 'Sea floor depth',
+      'units'    : 'm',
+  }
+  ds_out.attrs = {
+      'description' : 'Time-mean meridional velocity transect at {:.1f}N'.format(lat_transect),
+      'casename'    : casename,
+      'latitude'    : float(ds.yq),
+      'lon_min'     : lon_min,
+      'lon_max'     : lon_max,
+      'start_date'  : args.start_date,
+      'end_date'    : args.end_date,
+  }
+  outfile = 'ncfiles/{}_vo_mean_{:.1f}N_transect.nc'.format(casename, lat_transect)
+  ds_out.to_netcdf(outfile)
+  print('Saved:', outfile)
+
+  # --- Colour map matching the observation panels (Bilo & Johns 2020) ---
+  boundaries     = np.linspace(-0.3, 0.3, 50)
+  cmap_seismic   = plt.cm.get_cmap('seismic', len(boundaries))
+  colors         = list(cmap_seismic(np.arange(len(boundaries))))
+  cmap_custom    = mpl.colors.ListedColormap(colors, '')
+  cmap_custom.set_over(colors[-1])
+  cmap_custom.set_under(colors[0])
+
+  kw_color   = dict(vmin=-0.3, vmax=0.3, cmap=cmap_custom, zorder=0)
+  kw_contour = dict(levels=[-0.15, -0.1, -0.05, 0.03, 0.1, 0.2, 0.3],
+                    colors='k', linewidths=1, linestyles='solid', zorder=1)
+  kw_contourz = dict(levels=[0.0],
+                     colors='k', linewidths=2.5, linestyles='solid', zorder=1)
+
+  xh  = vo_mean.xh.values
+  z_l = vo_mean.z_l.values
+  vel = vo_mean.values
+
+  # --- Figure 1: single-panel model transect ---
+  fig, ax_lon, ax_dist = base_26N_transect(lon_min=lon_min, lon_max=lon_max)
+
+  cm = ax_lon.pcolormesh(xh, z_l, vel, **kw_color)
+
+  try:
+    c  = ax_lon.contour(xh, z_l, vel, **kw_contour)
+    cz = ax_lon.contour(xh, z_l, vel, **kw_contourz)
+    ax_lon.clabel(c,  fmt='%1.2f', colors='k',     fontsize=13, inline=True, zorder=14)
+    ax_lon.clabel(cz, fmt='%i',    colors='beige',  fontsize=15, inline=True, zorder=14)
+    [label.set_bbox(dict(edgecolor='none', facecolor='k', pad=0))
+     for label in ax_lon.findobj(mpl.text.Text) if label.get_text() == '0']
+  except Exception:
+    pass
+
+  # Model bathymetry overlay
+  ax_lon.fill_between(deptho.xh.values, deptho.values, y2=7000,
+                      color='saddlebrown', alpha=0.6, zorder=8, label='Model bathymetry')
+
+  # Colour bar
+  cbaxes = fig.add_axes([0.925, 0.115, 0.010, 0.77])
+  cb = fig.colorbar(cm, cax=cbaxes, extend='both',
+                    ticks=np.arange(-0.3, 0.35, 0.05))
+  cb.ax.tick_params(labelsize=13)
+  cb.ax.set_title(r'm s$^{-1}$', fontsize=13, x=1.3)
+
+  # Title
+  ax_lon.text(
+      lon_min + 0.3, 500,
+      '{:.1f}N  {}\n{} - {}'.format(lat_transect, label, args.start_date, args.end_date),
+      color='beige', fontsize=14,
+      bbox=dict(boxstyle='round', facecolor='k'), zorder=12)
+
+  savefig = 'PNG/DWBC/{}_vo_mean_{:.1f}N_transect.png'.format(casename, lat_transect)
+  fig.savefig(savefig, bbox_inches='tight', pad_inches=0.05, dpi=150)
+  print('Figure saved:', savefig)
+  plt.close(fig)
+
+  # --- Figure 2: 4-panel comparison (LADCP, MOCHA, Argo, MOM6) ---
+  ladcp  = xr.open_dataset(DWBC_DATA + '/ladcp_statistics.nc')
+  mocha  = xr.open_dataset(DWBC_DATA + '/mocha_currentmeter_dwbc_2008_2018.nc')
+  argo   = xr.open_dataset(DWBC_DATA + '/argo_vgeos_26.5N.nc')
+  argo_depth = -gsw.z_from_p(argo.pressure.values, lat_transect)
+
+  datasets = [
+      dict(label='LADCP',
+           x=ladcp.longitude.values,  y=ladcp.depth.values,
+           v=ladcp.v_mean.values / 100.0,   kind='contourf'),
+      dict(label='MOCHA moorings',
+           x=mocha.longitude.values, y=mocha.depth.values,
+           v=np.nanmean(mocha.v.values, axis=-1).T, kind='contourf'),
+      dict(label='Argo geostrophy',
+           x=argo.longitude[1:-1].values, y=argo_depth,
+           v=argo.v[:, 1:-1].values,      kind='pcolormesh'),
+      dict(label='{}\n{} - {}'.format(label, args.start_date, args.end_date),
+           x=xh, y=z_l,
+           v=vel,                          kind='pcolormesh'),
+  ]
+
+  topography = xr.open_dataset(DWBC_DATA + '/topography_26.5N.nc')
+
+  fig, axes = plt.subplots(2, 2, figsize=(18, 12), facecolor='w',
+                           sharex=False, sharey=True)
+  axes = axes.flatten()
+
+  for ax, d in zip(axes, datasets):
+    if d['kind'] == 'contourf':
+      cm = ax.contourf(d['x'], d['y'], d['v'],
+                       np.linspace(-0.3, 0.3, 50), **kw_color)
+    else:
+      cm = ax.pcolormesh(d['x'], d['y'], d['v'], **kw_color)
+
+    try:
+      ax.contour(d['x'], d['y'], d['v'], **kw_contour)
+      ax.contour(d['x'], d['y'], d['v'], **kw_contourz)
+    except Exception:
+      pass
+
+    # Topography
+    ax.fill_between(topography.longitude.values, topography.topography.values,
+                    y2=7000, color='k', zorder=10)
+
+    # Label
+    ax.text(0.03, 0.07, d['label'], transform=ax.transAxes,
+            color='beige', fontsize=14,
+            bbox=dict(boxstyle='round', facecolor='k'), zorder=12)
+
+    ax.set_ylim(5250, -20)
+    ax.set_xlim(lon_min, lon_max)
+    ax.set_ylabel('Depth (m)', fontsize=14)
+    ax.set_xlabel('Longitude', fontsize=14)
+    ax.tick_params(labelsize=12)
+
+    lon_ticks = np.arange(-77.0, -69.0, 1.0)
+    ax.set_xticks(lon_ticks)
+    ax.set_xticklabels([r'%i$^{\circ}$W' % int(abs(l)) for l in lon_ticks], fontsize=11)
+
+  # Shared colour bar
+  fig.subplots_adjust(right=0.88, hspace=0.3, wspace=0.25)
+  cbaxes = fig.add_axes([0.91, 0.12, 0.012, 0.76])
+  cb = fig.colorbar(cm, cax=cbaxes, extend='both',
+                    ticks=np.arange(-0.3, 0.35, 0.05))
+  cb.ax.tick_params(labelsize=12)
+  cb.ax.set_title(r'm s$^{-1}$', fontsize=12, x=1.5)
+
+  fig.suptitle('Mean meridional velocity at {:.1f}N'.format(lat_transect), fontsize=16)
+
+  savefig4 = 'PNG/DWBC/{}_vo_mean_{:.1f}N_4panel.png'.format(casename, lat_transect)
+  fig.savefig(savefig4, bbox_inches='tight', pad_inches=0.05, dpi=150)
+  print('Figure saved:', savefig4)
+  plt.close(fig)
+
+  if parallel:
+    print('\n Releasing workers...')
+    client.close(); cluster.close()
+
+  print('{} was run successfully!'.format(os.path.basename(__file__)))
+
+  return
+
+
+if __name__ == '__main__':
+  main()

--- a/mom6_tools/poleward_heat_transport.py
+++ b/mom6_tools/poleward_heat_transport.py
@@ -143,25 +143,23 @@ def main(stream=False):
   ds_mean = ds_ann.mean('time').load()
   print('Time elasped: ', datetime.now() - startTime)
 
-  print('Extract time series at 26.5 (Atlantic)...')
+  print('Extracting time series (Global and Atlantic)...')
   startTime = datetime.now()
-  # Heat Transport Time Series at 26.5°N (Atlantic)
-  ds_atl_ts =  (ds*basin_code_xr.sel(region='AtlanticOcean').rename({'yh':'yq'})).sel(yq=26.5,
-                method='nearest').sum('xh').drop(['yq', 'region'])
-  # Build a rename mapping
-  rename_dict = {var: f"{var}_rapid" for var in ds_atl_ts.data_vars}
-  # Apply renaming
-  ds_atl_ts = ds_atl_ts.rename(rename_dict)
-  print('Time elasped: ', datetime.now() - startTime)
 
-  print('Extract time series at the Equator (Global and Atlantic)...')
-  startTime = datetime.now()
   # Heat Transport Time Series at the Equator (Global)
   ds_global_eq_ts =  ds.sel(yq=0.0, method='nearest').sum('xh').drop('yq')
   # Build a rename mapping
   rename_dict = {var: f"{var}_global_eq" for var in ds_global_eq_ts.data_vars}
   # Apply renaming
   ds_global_eq_ts = ds_global_eq_ts.rename(rename_dict)
+
+  # Heat Transport Time Series at 60S (Global)
+  ds_global_60S_ts =  ds.sel(yq=-60.0, method='nearest').sum('xh').drop('yq')
+  # Build a rename mapping
+  rename_dict = {var: f"{var}_global_60S" for var in ds_global_60S_ts.data_vars}
+  # Apply renaming
+  ds_global_60S_ts = ds_global_60S_ts.rename(rename_dict)
+
   # Heat Transport Time Series at the Equator (Atlantic)
   ds_atl_eq_ts =  (ds*basin_code_xr.sel(region='AtlanticOcean').rename({'yh':'yq'})).sel(yq=0.0,
                   method='nearest').sum('xh').drop(['yq','region'])
@@ -169,15 +167,33 @@ def main(stream=False):
   rename_dict = {var: f"{var}_atl_eq" for var in ds_atl_eq_ts.data_vars}
   # Apply renaming
   ds_atl_eq_ts = ds_atl_eq_ts.rename(rename_dict)
+
+  # Heat Transport Time Series at 26.5°N (Atlantic)
+  ds_atl_ts =  (ds*basin_code_xr.sel(region='AtlanticOcean').rename({'yh':'yq'})).sel(yq=26.5,
+                method='nearest').sum('xh').drop(['yq', 'region'])
+  # Build a rename mapping
+  rename_dict = {var: f"{var}_rapid" for var in ds_atl_ts.data_vars}
+  # Apply renaming
+  ds_atl_ts = ds_atl_ts.rename(rename_dict)
+
+  # Heat Transport Time Series at 75N (Atlantic)
+  ds_atl_75N_ts =  (ds*basin_code_xr.sel(region='AtlanticOcean').rename({'yh':'yq'})).sel(yq=75.0,
+                  method='nearest').sum('xh').drop(['yq','region'])
+  # Build a rename mapping
+  rename_dict = {var: f"{var}_atl_75N" for var in ds_atl_75N_ts.data_vars}
+  # Apply renaming
+  ds_atl_75N_ts = ds_atl_75N_ts.rename(rename_dict)
+
   print('Time elasped: ', datetime.now() - startTime)
 
   # save time series
   # Merge along time dimension
-  ds_ts = xr.merge([ds_atl_ts, ds_atl_eq_ts, ds_global_eq_ts])
+  ds_ts = xr.merge([ds_atl_ts, ds_atl_eq_ts, ds_global_eq_ts, ds_atl_75N_ts, ds_global_60S_ts])
   varName = 'T_ady_2d'
   print('Saving time series...')
-  attrs = {'description': 'Time series of poleward heat transport by components at 26.5 N (Atlantic) \
-           and Equator (Global and Atlantic).','units': ds[varName].units, 'casename': args.casename}
+  attrs = {'description': 'Time series of poleward heat transport by components at Eq., 26.5 N and 75N (Atlantic) '
+                          'and Eq. and 60S (Global).',
+                          'units': ds[varName].units, 'casename': args.casename}
   add_global_attrs(ds_ts,attrs)
   ds_ts.to_netcdf('ncfiles/'+args.casename+'_heat_transport_ts.nc')
 

--- a/mom6_tools/wind_stress.py
+++ b/mom6_tools/wind_stress.py
@@ -1,158 +1,261 @@
 #!/usr/bin/env python
 
+"""
+Compute zonal-mean zonal wind stress and wind stress curl as functions of
+latitude and time. Produce Hovmoller diagrams for the Southern Ocean.
+
+Usage example (standalone):
+  python wind_stress.py '/path/to/archive/ocn/hist/*native*0001-??.nc'
+
+Usage example (yaml-based workflow):
+  python wind_stress.py diag_config.yml
+"""
+
 import xarray as xr
 import numpy as np
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
-import warnings, os, yaml, argparse
-import pandas as pd
-import dask
-from datetime import datetime, date
-from ncar_jobqueue import NCARCluster
-from dask.distributed import Client
-from mom6_tools.DiagsCase import DiagsCase
-from mom6_tools.m6toolbox import add_global_attrs
-from mom6_tools.m6plot import xycompare, xyplot
+import warnings, os, yaml, argparse, glob
+from datetime import datetime
+from scipy.ndimage import uniform_filter1d
+from xgcm import Grid
+from mom6_tools.m6toolbox import add_global_attrs, cime_xmlquery
 from mom6_tools.MOM6grid import MOM6grid
-from distributed import Client
+from pathlib import Path
+
 
 def parseCommandLine():
   """
   Parse the command line positional and optional arguments.
-  This is the highest level procedure invoked from the very end of the script.
   """
   parser = argparse.ArgumentParser(description=
       '''
-      Compute time-averages of surface variables (SST, SSS, SSU, SSV and MLD), and (when possible)
-      compare results against observational datasets.
+      Compute zonal-mean zonal wind stress and wind stress curl as functions
+      of latitude and time. Produce Hovmoller diagrams for the Southern Ocean.
       ''',
   epilog='Written by Gustavo Marques (gmarques@ucar.edu).')
-  parser.add_argument('diag_config_yml_path', type=str, help='''Full path to the yaml file  \
-    describing the run and diagnostics to be performed.''')
+  parser.add_argument('input_path', type=str, help='''Path to yaml config file
+    or glob pattern for native history files (e.g. '/path/*native*0001-??.nc').''')
   parser.add_argument('-sd','--start_date', type=str, default='',
-                      help='''Start year to compute averages. Default is to use value set in diag_config_yml_path''')
+                      help='''Start date to select data. Default is to use all available data
+                      (or value set in yaml config).''')
   parser.add_argument('-ed','--end_date', type=str, default='',
-                      help='''End year to compute averages. Default is to use value set in diag_config_yml_path''')
-  parser.add_argument('-fname','--file_name', type=str, default='.mom6.hm_*.nc',
-                      help='''File(s) where vmo should be read. Default .mom6.hm_*.nc''')
+                      help='''End date to select data. Default is to use all available data
+                      (or value set in yaml config).''')
+  parser.add_argument('-o','--output_dir', type=str, default='ncfiles',
+                      help='''Directory for output NetCDF files (default: ncfiles).''')
+  parser.add_argument('-p','--plot_dir', type=str, default='PNG/WIND',
+                      help='''Directory for output plots (default: PNG/WIND).''')
+  parser.add_argument('-label','--label', type=str, default='',
+                      help='''Label for the case (used in plot titles).''')
   parser.add_argument('-nw','--number_of_workers',  type=int, default=0,
                       help='''Number of workers to use (default=0, serial job).''')
-  parser.add_argument('-debug',   help='''Add priting statements for debugging purposes''', action="store_true")
   optCmdLineArgs = parser.parse_args()
   driver(optCmdLineArgs)
 
-#-- This is where all the action happends, i.e., functions for each diagnostic are called.
 
 def driver(args):
   nw = args.number_of_workers
-  fname = args.file_name
-  if not os.path.isdir('ncfiles'):
-    print('Creating a directory to place netCDF files (ncfiles)... \n')
-    os.system('mkdir ncfiles')
+  os.makedirs(args.output_dir, exist_ok=True)
+  os.makedirs(args.plot_dir, exist_ok=True)
 
-  # Read in the yaml file
-  diag_config_yml = yaml.load(open(args.diag_config_yml_path,'r'), Loader=yaml.Loader)
+  # Determine if input is a yaml config or a file glob pattern
+  if args.input_path.endswith('.yml') or args.input_path.endswith('.yaml'):
+    # yaml-based workflow
+    diag_config_yml = yaml.load(open(args.input_path,'r'), Loader=yaml.Loader)
+    caseroot = diag_config_yml['Case']['CASEROOT']
+    casename = cime_xmlquery(caseroot, 'CASE')
+    DOUT_S = cime_xmlquery(caseroot, 'DOUT_S')
+    if DOUT_S.lower() == "true":
+      OUTDIR = cime_xmlquery(caseroot, 'DOUT_S_ROOT')+'/ocn/hist/'
+    else:
+      OUTDIR = cime_xmlquery(caseroot, 'RUNDIR')
 
-  # Create the case instance
-  dcase = DiagsCase(diag_config_yml['Case'])
-  RUNDIR = dcase.get_value('RUNDIR')
-  args.casename = dcase.casename
-  print('Run directory is:', RUNDIR)
-  print('Casename is:', args.casename)
-  print('Number of workers: ', nw)
+    native_suffix = diag_config_yml['Fnames']['native']
+    file_pattern = OUTDIR + '/' + casename + native_suffix
+    avg = diag_config_yml['Avg']
+    if not args.start_date: args.start_date = avg['start_date']
+    if not args.end_date: args.end_date = avg['end_date']
+    if not args.label: args.label = diag_config_yml['Case'].get('SNAME', casename)
 
-  # set avg dates
-  avg = diag_config_yml['Avg']
-  if not args.start_date : args.start_date = avg['start_date']
-  if not args.end_date : args.end_date = avg['end_date']
+    # Use OCN_DIAG_ROOT from yaml for output directories
+    ocn_diag_root = diag_config_yml['Case'].get('OCN_DIAG_ROOT', '')
+    if ocn_diag_root:
+      args.output_dir = ocn_diag_root
+      args.plot_dir = os.path.join(ocn_diag_root, 'PNG', 'WIND')
+  else:
+    # standalone mode: input_path is a glob pattern
+    file_pattern = args.input_path
+    files = sorted(glob.glob(file_pattern))
+    if not files:
+      raise FileNotFoundError(f'No files matched: {file_pattern}')
+    casename = os.path.basename(files[0]).split('.mom6.')[0]
+    if not args.label: args.label = casename
 
-  # read grid info
-  grd = MOM6grid(RUNDIR+'/'+args.casename+'.mom6.static.nc')
+  print(f'Case: {casename}')
+  print(f'File pattern: {file_pattern}')
+  print(f'Number of workers: {nw}')
 
+  # Set up parallel processing
   parallel = False
   if nw > 1:
     parallel = True
+    from ncar_jobqueue import NCARCluster
+    from dask.distributed import Client
     cluster = NCARCluster()
-    cluster.scale(args.number_of_workers)
+    cluster.scale(nw)
     client = Client(cluster)
 
-  print('Reading {} dataset...'.format(args.file_name))
+  # Open dataset
+  print('Opening dataset...')
   startTime = datetime.now()
 
   def preprocess(ds):
-    ''' Return the dataset with variables'''
-    #variables = ['taux','tauy', 'time_bnds']
-    variables = ['tauuo','tauvo', 'time_bnds']
-    return ds[variables]
+    variables = ['tauuo', 'tauvo']
+    return ds[[v for v in variables if v in ds]]
 
-  ds = xr.open_mfdataset(RUNDIR+'/'+dcase.casename+fname, parallel=parallel)
+  ds = xr.open_mfdataset(file_pattern,
+                         preprocess=preprocess,
+                         data_vars='minimal',
+                         coords='minimal',
+                         compat='override',
+                         chunks={'time': 12})
+  print(f'Time elapsed: {datetime.now() - startTime}')
 
-  ds = preprocess(ds)
+  # Select time range if specified
+  if args.start_date and args.end_date:
+    print(f'Selecting data between {args.start_date} and {args.end_date}...')
+    ds = ds.sel(time=slice(args.start_date, args.end_date))
 
-  print('Time elasped: ', datetime.now() - startTime)
+  taux = ds['tauuo']  # (time, yh, xq) - zonal wind stress
+  tauy = ds['tauvo']  # (time, yq, xh) - meridional wind stress
 
-  print('Selecting data between {} and {}...'.format(args.start_date, args.end_date))
+  # ---- 1. Zonal-mean zonal wind stress ----
+  print('Computing zonal-mean zonal wind stress...')
   startTime = datetime.now()
-  ds = ds.sel(time=slice(args.start_date, args.end_date))
-  print('Time elasped: ', datetime.now() - startTime)
+  taux_zmean = taux.mean(dim='xq').compute()
+  taux_zmean.name = 'taux_zmean'
+  taux_zmean.attrs['long_name'] = 'Zonal-mean zonal wind stress'
+  taux_zmean.attrs['units'] = 'N m-2'
+  print(f'Time elapsed: {datetime.now() - startTime}')
 
-  print('Averaging in time...')
+  taux_ds = taux_zmean.to_dataset()
+  taux_ds.attrs = {
+      'description': 'Zonal-mean zonal wind stress as f(latitude, time)',
+      'casename': casename,
+      'module': os.path.basename(__file__)
+  }
+  taux_file = os.path.join(args.output_dir, f'{casename}_taux_zmean.nc')
+  taux_ds.to_netcdf(taux_file)
+  print(f'Saved: {taux_file}')
+
+  # ---- 2. Wind stress curl ----
+  print('Setting up xgcm grid...')
+  coords = {
+      'X': {'center': 'xh', 'right': 'xq'},
+      'Y': {'center': 'yh', 'right': 'yq'},
+  }
+  grid = Grid(ds, coords=coords, periodic=['X'], autoparse_metadata=False)
+
+  print('Computing wind stress curl...')
   startTime = datetime.now()
-  frc = ds.mean('time').compute()
-  print('Time elasped: ', datetime.now() - startTime)
+  curl = (
+      grid.diff(tauy, "X", boundary="fill")
+      - grid.diff(taux, "Y", boundary="fill")
+  ).load()
+  curl.name = 'wind_stress_curl'
+  print(f'Time elapsed: {datetime.now() - startTime}')
 
-  print('\n Plotting...')
-  if not os.path.isdir('PNG/WSTRESS'):
-    print('Creating a directory to place figures (PNG/WSTRESS)... \n')
-    os.system('mkdir -p PNG/WSTRESS')
+  # Determine dimension names after diff (should be xq, yq)
+  x_dim = [d for d in curl.dims if d.startswith('x')][0]
+  y_dim_curl = [d for d in curl.dims if d.startswith('y')][0]
 
-  taux_val = np.ma.masked_invalid(frc.tauuo.values)
-  tauy_val = np.ma.masked_invalid(frc.tauvo.values)
+  print('Computing zonal-mean wind stress curl...')
+  curl_zmean = curl.mean(dim=x_dim).compute()
+  curl_zmean.name = 'curl_zmean'
+  curl_zmean.attrs['long_name'] = 'Zonal-mean wind stress curl'
 
-  fig, ax = plt.subplots(nrows=1, ncols=2, figsize=(18,7), gridspec_kw={'width_ratios': [3, 1]})
-  xyplot(taux_val, grd.mgeolon_u, grd.geolat_u,
-         axis=ax[0], suptitle='Zonal surface stress [Pa] - '+str(args.casename),
-         title=str(args.start_date) + ' to '+ str(args.end_date))
-  frc.tauuo.mean(dim='xq').plot(ax=ax[1], y="yh")
-  ax[1].grid()
-  plt.savefig('PNG/WSTRESS/'+str(args.casename)+'_taux.png')
-  plt.close()
+  curl_ds = curl_zmean.to_dataset()
+  curl_ds.attrs = {
+      'description': 'Zonal-mean wind stress curl as f(latitude, time)',
+      'casename': casename,
+      'module': os.path.basename(__file__)
+  }
+  curl_file = os.path.join(args.output_dir, f'{casename}_curl_zmean.nc')
+  curl_ds.to_netcdf(curl_file)
+  print(f'Saved: {curl_file}')
 
-  fig, ax = plt.subplots(nrows=1, ncols=2, figsize=(18,7), gridspec_kw={'width_ratios': [3, 1]})
-  xyplot(tauy_val, grd.mgeolon_v, grd.geolat_v,
-         axis=ax[0], suptitle='Meridional surface stress [Pa] - '+str(args.casename),
-         title=str(args.start_date) + ' to '+ str(args.end_date))
-  frc.tauvo.mean(dim='xh').plot(ax=ax[1], y="yq")
-  ax[1].grid()
-  plt.savefig('PNG/WSTRESS/'+str(args.casename)+'_tauy.png')
-  plt.close()
+  # ---- 3. Hovmoller diagrams ----
+  print('Creating Hovmoller diagrams...')
 
-  # create dataarays
-  wind_da = xr.Dataset(
-             data_vars=dict(
-                taux=(["yh", "xq"], taux_val),
-                tauy=(["yq", "xh"], tauy_val),
-             ),
-             coords=dict(
-                lon_u=(["yh", "xq"], grd.geolon_u),
-                lat_u=(["yh", "xq"], grd.geolat_u),
-                lat_v=(["yq", "xh"], grd.geolat_v),
-                lon_v=(["yq", "xh"], grd.geolon_v)
-             ),
-             attrs = {'start_date': args.start_date,
-                      'end_date': args.end_date,
-                      'casename': args.casename,
-                      'description': 'Mean wind stress (Pa)',
-                      'module': os.path.basename(__file__)}
-             )
+  # Southern Ocean latitude range
+  lat_range = slice(-70, -40)
 
-  wind_da.to_netcdf('ncfiles/'+str(args.casename)+'_wind_stress.nc')
+  # Taux Hovmoller
+  taux_so = taux_zmean.sel(yh=lat_range)
+  plot_hovmoller(
+      taux_so, 'yh',
+      title=f'Zonal-mean zonal wind stress\n{args.label}',
+      cbar_label=r'$\tau_x$ [N m$^{-2}$]',
+      outfile=os.path.join(args.plot_dir, f'{casename}_hovmoller_taux.png')
+  )
+
+  # Curl Hovmoller
+  curl_so = curl_zmean.sel({y_dim_curl: lat_range})
+  plot_hovmoller(
+      curl_so, y_dim_curl,
+      title=f'Zonal-mean wind stress curl\n{args.label}',
+      cbar_label='Wind stress curl',
+      outfile=os.path.join(args.plot_dir, f'{casename}_hovmoller_curl.png'),
+      zero_contour=True
+  )
 
   if parallel:
-    print('\n Releasing workers...')
+    print('Releasing workers...')
     client.close(); cluster.close()
 
+  print(f'{os.path.basename(__file__)} completed successfully!')
   return
 
-# Invoke parseCommandLine(), the top-level prodedure
-if __name__ == '__main__': parseCommandLine()
 
+def plot_hovmoller(da, y_dim, title, cbar_label, outfile,
+                   zero_contour=False, smooth_window=12):
+  """Plot Hovmoller diagram with smoothed latitude of maximum overlaid."""
+  fig, ax = plt.subplots(figsize=(12, 6))
+
+  # Plot Hovmoller (time on x-axis, latitude on y-axis)
+  p = da.plot(ax=ax, x='time', y=y_dim, cmap='RdBu_r',
+              add_colorbar=True, cbar_kwargs={'label': cbar_label})
+
+  # Overlay zero contour for curl
+  if zero_contour:
+    da.plot.contour(ax=ax, x='time', y=y_dim, levels=[0],
+                    colors='gray', linewidths=1.0, linestyles='--')
+
+  # Find latitude of maximum at each time step
+  lat = da[y_dim]
+  idx_max = da.argmax(dim=y_dim, skipna=True)
+  lat_max = lat.isel({y_dim: idx_max}).values
+
+  # Smooth the lat-of-max line (running mean)
+  if len(lat_max) > smooth_window:
+    lat_max_smooth = uniform_filter1d(lat_max.astype(float),
+                                      size=smooth_window, mode='nearest')
+  else:
+    lat_max_smooth = lat_max
+
+  ax.plot(da.time, lat_max_smooth, 'k-', linewidth=1.5, label='Lat of max')
+
+  ax.legend(loc='upper right')
+  ax.set_title(title)
+  ax.set_xlabel('Time')
+  ax.set_ylabel('Latitude')
+  plt.tight_layout()
+  plt.savefig(outfile, dpi=150, bbox_inches='tight')
+  plt.close()
+  print(f'  Saved: {outfile}')
+
+
+# Invoke parseCommandLine(), the top-level procedure
+if __name__ == '__main__': parseCommandLine()

--- a/mom6_tools/wind_stress.py
+++ b/mom6_tools/wind_stress.py
@@ -52,7 +52,7 @@ def parseCommandLine():
   parser.add_argument('-nw','--number_of_workers',  type=int, default=0,
                       help='''Number of workers to use (default=0, serial job).''')
   optCmdLineArgs = parser.parse_args()
-  driver(optCmdLineArgs)
+  return optCmdLineArgs
 
 
 def driver(args):
@@ -257,5 +257,14 @@ def plot_hovmoller(da, y_dim, title, cbar_label, outfile,
   print(f'  Saved: {outfile}')
 
 
-# Invoke parseCommandLine(), the top-level procedure
-if __name__ == '__main__': parseCommandLine()
+def main():
+  '''
+  Main procedure that calls the driver.
+  '''
+  args = parseCommandLine()
+  driver(args)
+
+# Invoke main() which calls parseCommandLine() and the driver.
+if __name__ == '__main__':
+  main()
+

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
             'mom6-tools_create_mom6_tools=mom6_tools.create_mom6_tools:main',
             'mom6-tools_diff_rms=mom6_tools.diff_rms:main',
             'mom6-tools_drift=mom6_tools.drift:main',
+            'mom6-tools_dwbc=mom6_tools.dwbc:main',
             'mom6-tools_enso=mom6_tools.enso:main',
             'mom6-tools_equatorial_comparison=mom6_tools.equatorial_comparison:main',
             'mom6-tools_forcing=mom6_tools.forcing:main',


### PR DESCRIPTION
- New diagnostic: Deep Western Boundary Current (DWBC) at 26.5N — Adds dwbc.py, a new module that computes and plots the time-mean meridional velocity transect   at 26.5N (77W–70W), following Bilo & Johns (2020). Produces a single-panel model transect and a 4-panel comparison against LADCP, MOCHA moorings, and Argo geostrophy observations. Supports parallel execution via Dask.
- Additional heat transport time series locations — Extends poleward_heat_transport.py to extract heat transport time series at 75N (Atlantic) and 60S (Global), in addition to the existing 26.5N (Atlantic) and Equator (Global and Atlantic) locations. All five time series are merged and saved to the output NetCDF file.
- Rewrite of wind_stress.py for Hovmoller diagrams — Rewrites the wind stress module to compute zonal-mean zonal wind stress and wind stress curl as functions of latitude and time using xgcm. Produces Hovmoller diagrams for the Southern Ocean (70S–40S) with smoothed latitude-of-maximum overlay. Supports both standalone (glob pattern) and YAML-based workflows. Saves intermediate NetCDF files for both zonal-mean taux and curl.
- Broaden default file stream pattern — Changes the default --stream glob in  compute_basin_reductions.py from .mom6.h.native.????-??.nc to .mom6.h.native.*.nc   so it also matches annual mean files.